### PR TITLE
Add strtoul, strcpy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+* [#7] - Add `strtoul` and `strcpy`
+
+[#7]: https://github.com/rust-embedded-community/tinyrlibc/pull/7
+
 ## v0.2.2 (2022-03-17)
 
 * [#5] - Swap `i32` to `CInt` in `strchr`.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This crate basically came about so that the [nrfxlib](https://github.com/NordicP
 * atoi
 * strcmp
 * strncmp
+* strcpy
 * strncpy
 * strlen
 * strtol

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This crate basically came about so that the [nrfxlib](https://github.com/NordicP
 * strncpy
 * strlen
 * strtol
+* strtoul
 * strstr
 * strchr
 * snprintf

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,9 @@ pub use self::strcmp::strcmp;
 mod strncmp;
 pub use self::strncmp::strncmp;
 
+mod strcpy;
+pub use self::strcpy::strcpy;
+
 mod strncpy;
 pub use self::strncpy::strncpy;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,9 @@ pub use self::strlen::strlen;
 mod strtol;
 pub use self::strtol::strtol;
 
+mod strtoul;
+pub use self::strtoul::strtoul;
+
 mod strstr;
 pub use self::strstr::strstr;
 

--- a/src/strcpy.rs
+++ b/src/strcpy.rs
@@ -1,0 +1,48 @@
+//! Rust implementation of C library function `strcpy`
+//!
+//! Licensed under the Blue Oak Model Licence 1.0.0
+
+use crate::CChar;
+
+/// Rust implementation of C library function `strcpy`. Passing NULL
+/// (core::ptr::null()) gives undefined behaviour.
+#[no_mangle]
+pub unsafe extern "C" fn strcpy(
+    dest: *mut CChar,
+    src: *const CChar,
+) -> *const CChar {
+    let mut i = 0;
+    loop {
+        *dest.offset(i) = *src.offset(i);
+        let c = *dest.offset(i);
+        if c == 0 {
+            break;
+        }
+        i += 1;
+    }
+    dest
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn short() {
+        let src = b"hi\0";
+        let mut dest = *b"abcdef"; // no null terminator
+        let result = unsafe { strcpy(dest.as_mut_ptr(), src.as_ptr()) };
+        assert_eq!(
+            unsafe { core::slice::from_raw_parts(result, 5) },
+            *b"hi\0de"
+        );
+    }
+
+    #[test]
+    fn two() {
+        let src = b"hi\0";
+        let mut dest = [0u8; 2]; // no space for null terminator
+        let result = unsafe { strcpy(dest.as_mut_ptr(), src.as_ptr()) };
+        assert_eq!(unsafe { core::slice::from_raw_parts(result, 2) }, b"hi");
+    }
+}

--- a/src/strtoul.rs
+++ b/src/strtoul.rs
@@ -1,0 +1,68 @@
+//! Rust implementation of C library function `strtoul`
+//!
+//! Copyright (c) Jonathan 'theJPster' Pallant 2019
+//! Licensed under the Blue Oak Model Licence 1.0.0
+
+use crate::{CChar, CULong, CStringIter};
+
+/// Rust implementation of C library function `strtoul`.
+///
+/// Takes a null-terminated string and interprets it as a decimal integer.
+/// This integer is returned as a `CULong`. Parsing stops when the first
+/// non-digit ASCII byte is seen. If no valid ASCII digit bytes are seen, this
+/// function returns zero.
+#[no_mangle]
+pub unsafe extern "C" fn strtoul(s: *const CChar) -> CULong {
+    let mut result: CULong = 0;
+    for c in CStringIter::new(s) {
+        if c >= b'0' && c <= b'9' {
+            result *= 10;
+            result += (c - b'0') as CULong;
+        } else {
+            break;
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod test {
+    use super::strtoul;
+
+    #[test]
+    fn empty() {
+        let result = unsafe { strtoul(b"\0".as_ptr()) };
+        assert_eq!(result, 0);
+    }
+
+    #[test]
+    fn non_digit() {
+        let result = unsafe { strtoul(b"1234x\0".as_ptr()) };
+        assert_eq!(result, 1234);
+    }
+
+    #[test]
+    fn bad_number() {
+        let result = unsafe { strtoul(b"x\0".as_ptr()) };
+        assert_eq!(result, 0);
+    }
+
+    #[test]
+    fn one() {
+        let result = unsafe { strtoul(b"1\0".as_ptr()) };
+        assert_eq!(result, 1);
+    }
+
+    #[test]
+    fn hundredish() {
+        let result = unsafe { strtoul(b"123\0".as_ptr()) };
+        assert_eq!(result, 123);
+    }
+
+    #[test]
+    fn big_long() {
+        let result = unsafe { strtoul(b"2147483647\0".as_ptr()) };
+        assert_eq!(result, 2147483647);
+    }
+
+}


### PR DESCRIPTION
This will make it possible to link with nrfxlib v2.0x.

Added:
 - strcpy
 - strtoul