### PR TITLE
Use newly stabilized ::core::ffi types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,3 @@ repository = "https://github.com/thejpster/tinyrlibc"
 
 [build-dependencies]
 cc = "1.0"
-
-[features]
-# Set this feature to assume a C `long` is 64-bits (i.e. the C compiler uses
-# the LP64 model, rather than the LLP64, ILP32 or LP32 models). See
-# https://en.cppreference.com/w/cpp/language/types for more details.
-lp64 = []
-# Set this feature to assume a C `int` is 16-bits (i.e. the C compiler uses
-# the LP32 model, rather than the LP64, LLP64 or ILP32 models). See
-# https://en.cppreference.com/w/cpp/language/types for more details.
-lp32 = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,43 +51,23 @@ pub use self::itoa::itoa;
 
 mod snprintf;
 
-/// `long long int` is always 64-bits long.
-pub type CLongLong = i64;
+/// `long long int`
+pub type CLongLong = ::core::ffi::c_longlong;
 
-/// `unsigned long long int` is always 64-bits long.
-pub type CULongLong = i64;
+/// `unsigned long long int`
+pub type CULongLong = ::core::ffi::c_ulonglong;
 
-#[cfg(feature = "lp64")]
-/// The `lp64` feature means we assume `long int` is 64-bits.
-pub type CLong = i64;
+/// `long int`
+pub type CLong = ::core::ffi::c_long;
 
-#[cfg(feature = "lp64")]
-/// The `lp64` feature means we assume `unsigned long int` is 64-bits.
-pub type CULong = u64;
+/// `unsigned long int`
+pub type CULong = ::core::ffi::c_ulong;
 
-#[cfg(not(feature = "lp64"))]
-/// We assume `long int` is 32-bits.
-pub type CLong = i32;
+/// `int`
+pub type CInt = ::core::ffi::c_int;
 
-#[cfg(not(feature = "lp64"))]
-/// We assume `unsigned long int` is 32-bits.
-pub type CULong = u32;
-
-#[cfg(feature = "lp32")]
-/// The `lp32` feature means we assume `int` is 16-bits.
-pub type CInt = i16;
-
-#[cfg(feature = "lp32")]
-/// The `lp32` feature means we assume `unsigned int` is 16-bits.
-pub type CUInt = u16;
-
-#[cfg(not(feature = "lp32"))]
-/// We assume `int` is 32-bits.
-pub type CInt = i32;
-
-#[cfg(not(feature = "lp32"))]
-/// We assume `unsigned int` is 32-bits.
-pub type CUInt = u32;
+/// `unsigned int`
+pub type CUInt = ::core::ffi::c_uint;
 
 /// Represents an 8-bit `char`. Rust does not (and will never) support
 /// platforms where `char` is not 8-bits long.

--- a/src/snprintf.rs
+++ b/src/snprintf.rs
@@ -9,7 +9,7 @@ mod test {
 		fn snprintf(buf: *mut CChar, len: usize, fmt: *const CChar, ...) -> i32;
 	}
 
-	use crate::{strcmp::strcmp, CChar};
+	use crate::{strcmp::strcmp, CChar, CInt, CLong, CLongLong, CUInt, CULong, CULongLong};
 
 	#[test]
 	fn plain_string() {
@@ -66,7 +66,6 @@ mod test {
 	}
 
 	#[test]
-	#[cfg(feature = "lp64")]
 	fn numbers() {
 		let mut buf = [b'\0'; 64];
 		assert_eq!(
@@ -75,49 +74,15 @@ mod test {
 					buf.as_mut_ptr(),
 					buf.len(),
 					"%u %lu %llu %d %ld %lld %x %lx %llX\0".as_ptr(),
-					100u32,
-					100u64,
-					100u64,
-					-100i32,
-					-100i64,
-					-100i64,
-					0xcafe1234u32,
-					0xcafe1234u64,
-					0xcafe1234u64,
-				)
-			},
-			53
-		);
-		assert_eq!(
-			unsafe {
-				strcmp(
-					buf.as_ptr() as *const u8,
-					b"100 100 100 -100 -100 -100 cafe1234 cafe1234 CAFE1234\0" as *const u8,
-				)
-			},
-			0
-		);
-	}
-
-	#[test]
-	#[cfg(not(feature = "lp64"))]
-	fn numbers() {
-		let mut buf = [b'\0'; 64];
-		assert_eq!(
-			unsafe {
-				snprintf(
-					buf.as_mut_ptr(),
-					buf.len(),
-					"%u %lu %llu %d %ld %lld %x %lx %llX\0".as_ptr(),
-					100u32,
-					100u32,
-					100u64,
-					-100i32,
-					-100i32,
-					-100i64,
-					0xcafe1234u32,
-					0xcafe1234u64,
-					0xcafe1234u64,
+					CUInt::from(100u8),
+					CULong::from(100u8),
+					CULongLong::from(100u8),
+					CInt::from(-100i8),
+					CLong::from(-100i8),
+					CLongLong::from(-100i8),
+					CUInt::from(0xcafe1234u32),
+					CULong::from(0xcafe1234u32),
+					CULongLong::from(0xcafe1234u32),
 				)
 			},
 			53


### PR DESCRIPTION
Eliminates the necessity to make assumptions about integer sizes.

**IMPORTANT**: This is a breaking API change and will require a new major version.

- [x] Change types
- [x] Remove features
- [x] Adjust tests