### PR TITLE
Put every function behind a feature gate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,34 @@ repository = "https://github.com/thejpster/tinyrlibc"
 
 [build-dependencies]
 cc = "1.0"
+
+[features]
+default = ["all"]
+all = [
+    "abs",
+    "strcmp",
+    "strncmp",
+    "strcpy",
+    "strncpy",
+    "strlen",
+    "strtol",
+    "strtoul",
+    "strstr",
+    "strchr",
+    "atoi",
+    "itoa",
+    "snprintf",
+]
+abs = []
+strcmp = []
+strncmp = []
+strcpy = []
+strncpy = []
+strlen = []
+strtol = []
+strtoul = []
+strstr = []
+strchr = []
+atoi = []
+itoa = []
+snprintf = []

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,11 @@
 fn main() {
-	// Build our snprintf substitute (which has to be C as Rust doesn't do varargs)
-	cc::Build::new()
-		.warnings(true)
-		.extra_warnings(true)
-		.flag("-std=c99")
-		.file("./src/snprintf.c")
-		.compile("clocal");
+	if cfg!(feature = "snprintf") {
+		// Build our snprintf substitute (which has to be C as Rust doesn't do varargs)
+		cc::Build::new()
+			.warnings(true)
+			.extra_warnings(true)
+			.flag("-std=c99")
+			.file("./src/snprintf.c")
+			.compile("clocal");
+	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,42 +13,67 @@
 #[allow(unused_imports)]
 use std as core;
 
+#[cfg(feature = "abs")]
 mod abs;
+#[cfg(feature = "abs")]
 pub use self::abs::abs;
 
+#[cfg(feature = "strcmp")]
 mod strcmp;
+#[cfg(feature = "strcmp")]
 pub use self::strcmp::strcmp;
 
+#[cfg(feature = "strncmp")]
 mod strncmp;
+#[cfg(feature = "strncmp")]
 pub use self::strncmp::strncmp;
 
+#[cfg(feature = "strcpy")]
 mod strcpy;
+#[cfg(feature = "strcpy")]
 pub use self::strcpy::strcpy;
 
+#[cfg(feature = "strncpy")]
 mod strncpy;
+#[cfg(feature = "strncpy")]
 pub use self::strncpy::strncpy;
 
+#[cfg(feature = "strlen")]
 mod strlen;
+#[cfg(feature = "strlen")]
 pub use self::strlen::strlen;
 
+#[cfg(feature = "strtol")]
 mod strtol;
+#[cfg(feature = "strtol")]
 pub use self::strtol::strtol;
 
+#[cfg(feature = "strtoul")]
 mod strtoul;
+#[cfg(feature = "strtoul")]
 pub use self::strtoul::strtoul;
 
+#[cfg(feature = "strstr")]
 mod strstr;
+#[cfg(feature = "strstr")]
 pub use self::strstr::strstr;
 
+#[cfg(feature = "strchr")]
 mod strchr;
+#[cfg(feature = "strchr")]
 pub use self::strchr::strchr;
 
+#[cfg(feature = "atoi")]
 mod atoi;
+#[cfg(feature = "atoi")]
 pub use self::atoi::atoi;
 
+#[cfg(feature = "itoa")]
 mod itoa;
+#[cfg(feature = "itoa")]
 pub use self::itoa::itoa;
 
+#[cfg(feature = "snprintf")]
 mod snprintf;
 
 /// `long long int`


### PR DESCRIPTION
I've come across a C library that implements some libc functions on its own but not others. I want to use this crate but it collides.
This way you can customize which functions you want to use.