### PR TITLE
Add critical-section dependency and signal module

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           use-cross: true
           command: build
-          args: --target=${{ matrix.TARGET }}
+          args: --target=${{ matrix.TARGET }} --all-features
 
   test:
     name: Tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,6 @@ all = [
     "isdigit",
     "isalpha",
     "isupper",
-    "alloc",
-    "signal",
 ]
 abs = []
 strcmp = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,11 @@ readme = "README.md"
 repository = "https://github.com/thejpster/tinyrlibc"
 
 [dependencies]
+critical-section = "1.1.2"
 
 [dev-dependencies]
 static-alloc = "0.2.4"
+critical-section = { version = "1.1.2", features = ["std"]}
 
 [build-dependencies]
 cc = "1.0"
@@ -42,6 +44,7 @@ all = [
     "isalpha",
     "isupper",
     "alloc",
+    "signal",
 ]
 abs = []
 strcmp = []
@@ -66,3 +69,4 @@ isdigit = []
 isalpha = []
 isupper = []
 alloc = []
+signal = []

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ This crate basically came about so that the [nrfxlib](https://github.com/NordicP
     * calloc
     * realloc
     * free
+* signal
+    * signal
+    * raise
+    * abort
 
 ## Non-standard helper functions
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This crate basically came about so that the [nrfxlib](https://github.com/NordicP
     * calloc
     * realloc
     * free
-* signal
+* signal (optional)
     * signal
     * raise
     * abort

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,15 +16,6 @@ mod malloc;
 #[cfg(feature = "alloc")]
 pub use self::malloc::{calloc, free, malloc, realloc};
 
-// A new global allocator is required for the tests, but not for the library itself.
-// This is because the default alloc crate uses the system allocator, collides with
-// the one in this crate, and causes a link error.
-#[cfg(all(feature = "alloc", test))]
-use static_alloc::Bump;
-#[cfg(all(feature = "alloc", test))]
-#[global_allocator]
-static ALLOCATOR: Bump<[u8; 1024 * 1024]> = Bump::uninit();
-
 mod itoa;
 #[cfg(feature = "itoa")]
 pub use self::itoa::itoa;
@@ -86,6 +77,10 @@ pub use self::strstr::strstr;
 mod strchr;
 #[cfg(feature = "strchr")]
 pub use self::strchr::strchr;
+
+mod signal;
+#[cfg(feature = "signal")]
+pub use self::signal::{abort, raise, signal};
 
 mod snprintf;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@ mod strchr;
 #[cfg(feature = "strchr")]
 pub use self::strchr::strchr;
 
+#[cfg(feature = "signal")]
 mod signal;
 #[cfg(feature = "signal")]
 pub use self::signal::{abort, raise, signal};

--- a/src/malloc.rs
+++ b/src/malloc.rs
@@ -12,7 +12,7 @@ const MAX_ALIGN: usize = 16;
 /// Rust implementation of C library function `malloc`
 ///
 /// See [malloc](https://linux.die.net/man/3/malloc) for alignment details.
-#[no_mangle]
+#[cfg_attr(not(test), no_mangle)]
 pub unsafe extern "C" fn malloc(size: CSizeT) -> *mut u8 {
 	// size + MAX_ALIGN for to store the size of the allocated memory.
 	let layout = alloc::alloc::Layout::from_size_align(size + MAX_ALIGN, MAX_ALIGN).unwrap();
@@ -29,7 +29,7 @@ pub unsafe extern "C" fn malloc(size: CSizeT) -> *mut u8 {
 /// Rust implementation of C library function `calloc`
 ///
 /// See [calloc](https://linux.die.net/man/3/calloc) for alignment details.
-#[no_mangle]
+#[cfg_attr(not(test), no_mangle)]
 pub unsafe extern "C" fn calloc(nmemb: CSizeT, size: CSizeT) -> *mut u8 {
 	let total_size = nmemb * size;
 	let layout = alloc::alloc::Layout::from_size_align(total_size + MAX_ALIGN, MAX_ALIGN).unwrap();
@@ -46,7 +46,7 @@ pub unsafe extern "C" fn calloc(nmemb: CSizeT, size: CSizeT) -> *mut u8 {
 /// Rust implementation of C library function `realloc`
 ///
 /// See [realloc](https://linux.die.net/man/3/realloc) for alignment details.
-#[no_mangle]
+#[cfg_attr(not(test), no_mangle)]
 pub unsafe extern "C" fn realloc(ptr: *mut u8, size: CSizeT) -> *mut u8 {
 	if ptr.is_null() {
 		return malloc(size);
@@ -64,7 +64,7 @@ pub unsafe extern "C" fn realloc(ptr: *mut u8, size: CSizeT) -> *mut u8 {
 }
 
 /// Rust implementation of C library function `free`
-#[no_mangle]
+#[cfg_attr(not(test), no_mangle)]
 pub unsafe extern "C" fn free(ptr: *mut u8) {
 	if ptr.is_null() {
 		return;

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1,0 +1,134 @@
+//! Rust implementation of the C standard library's `signal` related functions.
+//!
+//! Licensed under the Blue Oak Model Licence 1.0.0
+
+use core::cell::RefCell;
+use critical_section::Mutex;
+
+// Signal hanling is emulated by the `critical-section` crate.
+static SIGNAL_HANDLERS: Mutex<RefCell<[extern "C" fn(i32); 16]>> =
+	Mutex::new(RefCell::new([default_handler; 16]));
+
+const SIG_DFL: usize = 0;
+const SIG_IGN: usize = 1;
+const SIG_ERR: isize = -1;
+
+// Only ANSI C signals are now supported.
+// SIGSEGV, SIGILL, SIGFPE are not supported on bare metal, but handlers are invoked when raise() is called.
+// TODO: Support SIGSEGV, SIGILL, SIGFPE by using the `cortex-m-rt` or `riscv-rt` crate.
+const SIGTERM: i32 = 15;
+const SIGSEGV: i32 = 11;
+const SIGINT: i32 = 2;
+const SIGILL: i32 = 4;
+const SIGABRT: i32 = 6;
+const SIGFPE: i32 = 8;
+
+const SIGNALS: [i32; 6] = [SIGTERM, SIGSEGV, SIGINT, SIGILL, SIGABRT, SIGFPE];
+
+extern "C" fn ignore_handler(_sig: i32) {}
+
+extern "C" fn default_handler(_sig: i32) {
+	// TODO: This should call core::intrinsics::abort() but that's unstable.
+	panic!("Aborted");
+}
+
+/// Rust implementation of the C standard library's `signal` function.
+#[cfg_attr(all(not(test), feature = "signal"), no_mangle)]
+pub unsafe extern "C" fn signal(sig: i32, handler: extern "C" fn(i32)) -> extern "C" fn(i32) {
+	if SIGNALS.iter().all(|&s| s != sig) {
+		return core::mem::transmute(SIG_ERR);
+	}
+	critical_section::with(|cs| {
+		let mut handlers = SIGNAL_HANDLERS.borrow(cs).borrow_mut();
+		let old_handler = handlers[sig as usize];
+		handlers[sig as usize] = handler;
+		old_handler
+	})
+}
+
+/// Rust implementation of the C standard library's `raise` function.
+#[cfg_attr(all(not(test), feature = "signal"), no_mangle)]
+pub unsafe extern "C" fn raise(sig: i32) -> i32 {
+	if SIGNALS.iter().all(|&s| s != sig) {
+		return -1;
+	}
+	critical_section::with(|cs| {
+		let handlers = SIGNAL_HANDLERS.borrow(cs).borrow();
+		let handler = handlers[sig as usize];
+		match handler as usize {
+			SIG_DFL => default_handler(sig),
+			SIG_IGN => ignore_handler(sig),
+			_ => handler(sig),
+		}
+		0
+	})
+}
+
+#[cfg_attr(all(not(test), feature = "signal"), no_mangle)]
+pub extern "C" fn abort() {
+	unsafe {
+		raise(SIGABRT);
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_signal() {
+		unsafe {
+			static COUNT: Mutex<RefCell<i32>> = Mutex::new(RefCell::new(0));
+			extern "C" fn count_handler(_sig: i32) {
+				critical_section::with(|cs| {
+					let mut count = COUNT.borrow(cs).borrow_mut();
+					*count += 1;
+				});
+			}
+			println!("default_handler: {}", default_handler as usize);
+			println!("count_handler: {}", count_handler as usize);
+			let old_handler = signal(SIGTERM, count_handler);
+			println!("old_handler: {}", old_handler as usize);
+			println!("count_handler: {}", count_handler as usize);
+			println!("default_handler: {}", default_handler as usize);
+			assert_eq!(old_handler as usize, default_handler as usize);
+			(0..10).for_each(|_| {
+				raise(SIGTERM);
+			});
+			let old_handler = signal(SIGTERM, default_handler);
+			critical_section::with(|cs| {
+				let count = COUNT.borrow(cs).borrow();
+				assert_eq!(*count, 10);
+			});
+			assert_eq!(old_handler as usize, count_handler as usize);
+		}
+	}
+
+	#[test]
+	fn test_abort() {
+		let result = std::panic::catch_unwind(|| {
+			abort();
+		});
+		assert!(result.is_err());
+	}
+
+	#[test]
+	fn test_abort_signal() {
+		static TRIGGER: Mutex<RefCell<bool>> = Mutex::new(RefCell::new(false));
+		extern "C" fn trigger_handler(_sig: i32) {
+			critical_section::with(|cs| {
+				let mut trigger = TRIGGER.borrow(cs).borrow_mut();
+				*trigger = true;
+			});
+		}
+		unsafe { signal(SIGABRT, trigger_handler) };
+		let result = std::panic::catch_unwind(|| {
+			abort();
+		});
+		assert!(result.is_ok());
+		critical_section::with(|cs| {
+			let trigger = TRIGGER.borrow(cs).borrow();
+			assert!(*trigger);
+		});
+	}
+}


### PR DESCRIPTION
This adds Rust implementation of `signal`, `raise`, and `abort` to ANSI C signals: `SIGTERM`, `SIGSEGV`, `SIGINT`, `SIGILL`, `SIGABRT`, `SIGFPE`.

A few caveats: 
- `core::intrinsics::abort()` is unstable, so the default handler panics.
- Technically, `SIGSEGV`, `SIGILL`, `SIGFPE` can be implemented using exception handlers, but I am not sure if this breaks things when used in other crates.