### PR TITLE
Add strncasecmp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* None
+* [#23] - Add `strncasecmp` 
 
 ## v0.3.0 (2022-10-18)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ all = [
     "abs",
     "strcmp",
     "strncmp",
+    "strncasecmp",
     "strcpy",
     "strncpy",
     "strlen",
@@ -46,6 +47,7 @@ all = [
 abs = []
 strcmp = []
 strncmp = []
+strncasecmp = []
 strcpy = []
 strncpy = []
 strlen = []

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This crate basically came about so that the [nrfxlib](https://github.com/NordicP
 * isupper
 * strcmp
 * strncmp
+* strncasecmp
 * strcpy
 * strncpy
 * strlen

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,10 @@ mod strncmp;
 #[cfg(feature = "strncmp")]
 pub use self::strncmp::strncmp;
 
+mod strncasecmp;
+#[cfg(feature = "strncasecmp")]
+pub use self::strncasecmp::strncasecmp;
+
 mod strcpy;
 #[cfg(feature = "strcpy")]
 pub use self::strcpy::strcpy;

--- a/src/strncasecmp.rs
+++ b/src/strncasecmp.rs
@@ -1,0 +1,53 @@
+//! Rust implementation of C library function `strncasecmp`
+//!
+//! Licensed under the Blue Oak Model Licence 1.0.0
+
+use crate::{CChar, CInt};
+
+/// Rust implementation of C library function `strncasecmp`. Passing NULL
+/// (core::ptr::null()) gives undefined behaviour.
+#[cfg_attr(feature = "strncasecmp", no_mangle)]
+pub unsafe extern "C" fn strncasecmp(s1: *const CChar, s2: *const CChar, n: usize) -> CInt {
+	for i in 0..n as isize {
+		let s1_i = s1.offset(i);
+		let s2_i = s2.offset(i);
+
+		let val = (*s1_i).to_ascii_lowercase() as CInt - (*s2_i).to_ascii_lowercase() as CInt;
+		if val != 0 || *s1_i == 0 {
+			return val;
+		}
+	}
+	0
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+
+	#[test]
+	fn matches() {
+		let a = b"abc\0";
+		let b = b"AbCDEF\0";
+		let result = unsafe { strncasecmp(a.as_ptr(), b.as_ptr(), 3) };
+		// Match!
+		assert_eq!(result, 0);
+	}
+
+	#[test]
+	fn no_match() {
+		let a = b"123\0";
+		let b = b"x1234\0";
+		let result = unsafe { strncasecmp(a.as_ptr(), b.as_ptr(), 3) };
+		// No match, first string first
+		assert!(result < 0);
+	}
+
+	#[test]
+	fn no_match2() {
+		let a = b"bbbbb\0";
+		let b = b"aaaaa\0";
+		let result = unsafe { strncasecmp(a.as_ptr(), b.as_ptr(), 3) };
+		// No match, second string first
+		assert!(result > 0);
+	}
+}

--- a/src/strncasecmp.rs
+++ b/src/strncasecmp.rs
@@ -8,9 +8,9 @@ use crate::{CChar, CInt};
 /// (core::ptr::null()) gives undefined behaviour.
 #[cfg_attr(feature = "strncasecmp", no_mangle)]
 pub unsafe extern "C" fn strncasecmp(s1: *const CChar, s2: *const CChar, n: usize) -> CInt {
-	for i in 0..n as isize {
-		let s1_i = s1.offset(i);
-		let s2_i = s2.offset(i);
+	for i in 0..n {
+		let s1_i = s1.add(i);
+		let s2_i = s2.add(i);
 
 		let val = (*s1_i).to_ascii_lowercase() as CInt - (*s2_i).to_ascii_lowercase() as CInt;
 		if val != 0 || *s1_i == 0 {


### PR DESCRIPTION
Adds `strncasecmp`, required by latest version of nrfxlib.