### PR TITLE
Release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,19 @@
 
 ## Unreleased
 
+* None
+
+## v0.4.0 (2024-03-22)
+
 * [#23] - Add `strncasecmp`
 * [#21] - Add signal API
+* [#19] - Add malloc/free API
+* [#14] - C function exports now gated by feature flags
 
-[#23]: https://github.com/rust-embedded-community/tinyrlibc/pull/21
+[#23]: https://github.com/rust-embedded-community/tinyrlibc/pull/23
 [#21]: https://github.com/rust-embedded-community/tinyrlibc/pull/21
+[#19]: https://github.com/rust-embedded-community/tinyrlibc/pull/19
+[#14]: https://github.com/rust-embedded-community/tinyrlibc/pull/14
 
 ## v0.3.0 (2022-10-18)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "tinyrlibc"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Jonathan 'theJPster' Pallant <github@thejpster.org.uk>"]
 edition = "2021"
 description = "Tiny, incomplete C library for bare-metal targets, written in Stable (but Unsafe) Rust"
 license-file = "LICENCES.md"
 readme = "README.md"
-repository = "https://github.com/thejpster/tinyrlibc"
+repository = "https://github.com/rust-embedded-community/tinyrlibc"
 
 [dependencies]
 portable-atomic = { version = "1.6.0", optional = true }


### PR DESCRIPTION
Also added some missing CHANGELOG entries.

Push v0.4.0 tag and publish to crates.io once merged.