### PR TITLE
Cleanup docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,60 +21,61 @@ cc = "1.0"
 default = ["all"]
 all = [
     "abs",
-    "strcmp",
-    "strncmp",
-    "strncasecmp",
-    "strcpy",
-    "strcat",
-    "strncpy",
-    "strlen",
-    "strtol",
-    "strtoul",
-    "strtoll",
-    "strtoull",
-    "strtoimax",
-    "strtoumax",
-    "strstr",
-    "strchr",
-    "strrchr",
     "atoi",
-    "utoa",
-    "itoa",
-    "snprintf",
-    "isspace",
-    "isdigit",
     "isalpha",
+    "isdigit",
+    "isspace",
     "isupper",
+    "itoa",
     "memchr",
     "qsort",
+    "snprintf",
+    "strcat",
+    "strchr",
+    "strcmp",
+    "strcpy",
+    "strlen",
+    "strncasecmp",
+    "strncmp",
+    "strncpy",
+    "strrchr",
+    "strstr",
+    "strtoimax",
+    "strtol",
+    "strtoll",
+    "strtoul",
+    "strtoull",
+    "strtoumax",
+    "utoa",
 ]
+
 abs = []
-strcmp = []
-strncmp = []
-strncasecmp = []
-strcpy = []
-strcat = []
-strncpy = []
-strlen = []
-strtol = []
-strtoul = []
-strtoll = []
-strtoull = []
-strtoimax = []
-strtoumax = []
-strstr = []
-strchr = []
-strrchr = []
-atoi = []
-utoa = []
-itoa = []
-snprintf = []
-isspace = []
-isdigit = []
-isalpha = []
-isupper = []
 alloc = []
+atoi = []
+isalpha = []
+isdigit = []
+isspace = []
+isupper = []
+itoa = []
 memchr = []
 qsort = []
 signal = ["dep:portable-atomic"]
 signal-cs = ["portable-atomic/critical-section"]
+snprintf = []
+strcat = []
+strchr = []
+strcmp = []
+strcpy = []
+strlen = []
+strncasecmp = []
+strncmp = []
+strncpy = []
+strrchr = []
+strstr = []
+strtoimax = []
+strtol = []
+strtoll = []
+strtoul = []
+strtoull = []
+strtoumax = []
+utoa = []

--- a/src/ctype.rs
+++ b/src/ctype.rs
@@ -37,8 +37,10 @@ pub type CInt = ::core::ffi::c_int;
 /// `unsigned int`
 pub type CUInt = ::core::ffi::c_uint;
 
-/// Represents an 8-bit `char`. Rust does not (and will never) support
-/// platforms where `char` is not 8-bits long.
+/// Represents an 8-bit `char`.
+///
+/// Rust does not (and will never) support platforms where `char` is not 8-bits
+/// long.
 pub type CChar = u8;
 
 /// This allows you to iterate a null-terminated string in a relatively simple
@@ -49,8 +51,9 @@ pub struct CStringIter {
 }
 
 impl CStringIter {
-	/// Create a new iterator from a pointer to a null-terminated string. The
-	/// behaviour is undefined if the string is not null-terminated.
+	/// Create a new iterator from a pointer to a null-terminated string.
+	///
+	/// The behaviour is undefined if the string is not null-terminated.
 	pub fn new(s: *const CChar) -> CStringIter {
 		CStringIter { ptr: s, idx: 0 }
 	}

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -15,8 +15,9 @@ const SIG_DFL_ATOMIC: AtomicUsize = AtomicUsize::new(SIG_DFL);
 
 /// Our array of registered signal handlers.
 ///
-/// Signals in C are either 0, 1, -1, or a function pointer. We cast function
-/// pointers into `usize` so they can be stored in this array.
+/// Signals in C are either 0, 1, -1, or a function pointer.
+///
+/// We cast function pointers into `usize` so they can be stored in this array.
 static SIGNAL_HANDLERS: [AtomicUsize; 16] = [SIG_DFL_ATOMIC; 16];
 
 /// A signal handler - either a function pointer or a magic integer.

--- a/src/strcat.rs
+++ b/src/strcat.rs
@@ -4,8 +4,9 @@
 
 use crate::CChar;
 
-/// Rust implementation of C library function `strcat`. Passing NULL
-/// (core::ptr::null()) gives undefined behaviour.
+/// Rust implementation of C library function `strcat`.
+///
+/// Passing NULL (core::ptr::null()) gives undefined behaviour.
 #[cfg_attr(feature = "strcat", no_mangle)]
 pub unsafe extern "C" fn strcat(dest: *mut CChar, src: *const CChar) -> *const CChar {
 	crate::strcpy::strcpy(dest.add(crate::strlen::strlen(dest)), src);

--- a/src/strcpy.rs
+++ b/src/strcpy.rs
@@ -4,8 +4,9 @@
 
 use crate::CChar;
 
-/// Rust implementation of C library function `strcpy`. Passing NULL
-/// (core::ptr::null()) gives undefined behaviour.
+/// Rust implementation of C library function `strcpy`.
+///
+/// Passing NULL (core::ptr::null()) gives undefined behaviour.
 #[cfg_attr(feature = "strcpy", no_mangle)]
 pub unsafe extern "C" fn strcpy(dest: *mut CChar, src: *const CChar) -> *const CChar {
 	let mut i = 0;

--- a/src/strncasecmp.rs
+++ b/src/strncasecmp.rs
@@ -4,8 +4,9 @@
 
 use crate::{CChar, CInt};
 
-/// Rust implementation of C library function `strncasecmp`. Passing NULL
-/// (core::ptr::null()) gives undefined behaviour.
+/// Rust implementation of C library function `strncasecmp`.
+///
+/// Passing NULL (core::ptr::null()) gives undefined behaviour.
 #[cfg_attr(feature = "strncasecmp", no_mangle)]
 pub unsafe extern "C" fn strncasecmp(s1: *const CChar, s2: *const CChar, n: usize) -> CInt {
 	for i in 0..n {

--- a/src/strncmp.rs
+++ b/src/strncmp.rs
@@ -5,8 +5,9 @@
 
 use crate::{CChar, CInt};
 
-/// Rust implementation of C library function `strncmp`. Passing NULL
-/// (core::ptr::null()) gives undefined behaviour.
+/// Rust implementation of C library function `strncmp`.
+///
+/// Passing NULL (core::ptr::null()) gives undefined behaviour.
 #[cfg_attr(feature = "strncmp", no_mangle)]
 pub unsafe extern "C" fn strncmp(s1: *const CChar, s2: *const CChar, n: usize) -> crate::CInt {
 	for i in 0..n as isize {

--- a/src/strncpy.rs
+++ b/src/strncpy.rs
@@ -5,8 +5,9 @@
 
 use crate::CChar;
 
-/// Rust implementation of C library function `strncmp`. Passing NULL
-/// (core::ptr::null()) gives undefined behaviour.
+/// Rust implementation of C library function `strncmp`.
+///
+/// Passing NULL (core::ptr::null()) gives undefined behaviour.
 #[cfg_attr(feature = "strncpy", no_mangle)]
 pub unsafe extern "C" fn strncpy(
 	dest: *mut CChar,


### PR DESCRIPTION
1. Ensure doc comments have short summary.
2. Ensure features in `Cargo.toml` are sorted.
