### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.5.0 (2024-11-29)
+
 * [#26] - Add `memchr` 
 * [#27] - Add `qsort`
 * [#28] - Add `strcat` and `strchr`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tinyrlibc"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Jonathan 'theJPster' Pallant <github@thejpster.org.uk>"]
 edition = "2021"
 description = "Tiny, incomplete C library for bare-metal targets, written in Stable (but Unsafe) Rust"


### PR DESCRIPTION
We could release as 0.4.1, but you only need these functions when you *actually* need them, and adding extra public no-mangled symbols to a project without asking might be problematic. So, every release is a breaking change and if you need the new APIs, you can just update to it.