### PR TITLE
Release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## v0.5.1 (2026-01-04)
+
+* [#38] - Enable all features on `docs.rs`
+
+[#38]: https://github.com/rust-embedded-community/tinyrlibc/pull/26
+
 ## v0.5.0 (2024-11-29)
 
 * [#26] - Add `memchr` 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tinyrlibc"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Jonathan 'theJPster' Pallant <github@thejpster.org.uk>"]
 edition = "2021"
 description = "Tiny, incomplete C library for bare-metal targets, written in Stable (but Unsafe) Rust"


### PR DESCRIPTION
Do a release of v0.5.1 with the docs.rs fix (#38) before the breaking changes go in.